### PR TITLE
Review scripts: harden existing scripts and add automation hub

### DIFF
--- a/BulkAddExternalContacts.ps1
+++ b/BulkAddExternalContacts.ps1
@@ -1,1 +1,102 @@
-﻿Import-Csv .\ExternalContacts.csv|%{New-MailContact -Name $_.Name -DisplayName $_.Name -ExternalEmailAddress $_.ExternalEmailAddress -FirstName $_.FirstName -LastName $_.LastName}
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Bulk imports external mail contacts from a CSV file.
+
+.DESCRIPTION
+    Reads a CSV and creates Exchange mail contacts for each row. Skips contacts
+    that already exist. Reports successes, failures, and skips.
+
+.PARAMETER CsvPath
+    Path to the CSV file. Required columns: Name, ExternalEmailAddress,
+    FirstName, LastName. Defaults to .\ExternalContacts.csv
+
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.EXAMPLE
+    .\BulkAddExternalContacts.ps1 -CsvPath C:\Data\contacts.csv
+
+.NOTES
+    Improved: added parameters, CSV validation, duplicate detection, per-contact
+    error handling, result summary, and logging.
+    Original: one-liner with no validation, error handling, or logging.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$CsvPath = ".\ExternalContacts.csv"
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "BulkAddExternalContacts"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+}
+
+if (-not (Test-Path $CsvPath)) {
+    Write-Log "CSV file not found: $CsvPath" -Level ERROR
+    throw "CSV not found: $CsvPath"
+}
+
+$contacts = Import-Csv -Path $CsvPath
+if (-not $contacts) {
+    Write-Log "CSV is empty: $CsvPath" -Level ERROR
+    throw "CSV is empty."
+}
+
+$required = @('Name', 'ExternalEmailAddress', 'FirstName', 'LastName')
+foreach ($col in $required) {
+    if ($col -notin $contacts[0].PSObject.Properties.Name) {
+        Write-Log "CSV missing required column: '$col'" -Level ERROR
+        throw "Missing column: $col"
+    }
+}
+
+Write-Log "CSV loaded: $CsvPath ($($contacts.Count) rows)" -Level INFO
+
+$successCount = 0
+$skipCount    = 0
+$failCount    = 0
+
+foreach ($contact in $contacts) {
+    $name  = $contact.Name
+    $email = $contact.ExternalEmailAddress
+
+    if (-not $name -or -not $email) {
+        Write-Log "Skipping row with missing Name or ExternalEmailAddress." -Level WARN
+        $skipCount++
+        continue
+    }
+
+    # Skip if contact already exists
+    $existing = Get-MailContact -Identity $email -ErrorAction SilentlyContinue
+    if ($existing) {
+        Write-Log "Already exists, skipping: $email" -Level WARN
+        $skipCount++
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($email, "New-MailContact '$name'")) {
+        try {
+            New-MailContact `
+                -Name $name `
+                -DisplayName $name `
+                -ExternalEmailAddress $email `
+                -FirstName $contact.FirstName `
+                -LastName $contact.LastName `
+                -ErrorAction Stop | Out-Null
+            Write-Log "Created contact: $name <$email>" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "FAILED: $name <$email> - $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Created: $successCount  |  Skipped: $skipCount  |  Failed: $failCount" -Level INFO

--- a/Connectto365.ps1
+++ b/Connectto365.ps1
@@ -1,7 +1,80 @@
-﻿
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Connects to Exchange Online using modern or legacy authentication.
 
-$LiveCred = Get-Credential
+.DESCRIPTION
+    Establishes an Exchange Online PowerShell session. Prefers the modern
+    ExchangeOnlineManagement module (V2/V3). Use -LegacyMode for older
+    tenants that still rely on basic-auth remote PowerShell sessions.
 
-$Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell/ -Credential $LiveCred -Authentication Basic -AllowRedirection
+.PARAMETER UserPrincipalName
+    Admin UPN used for authentication. If omitted, you will be prompted.
 
-Import-PSSession $Session
+.PARAMETER LegacyMode
+    Use the old New-PSSession / basic-auth method instead of the EXO V2/V3 module.
+
+.EXAMPLE
+    .\Connectto365.ps1 -UserPrincipalName admin@contoso.onmicrosoft.com
+
+.EXAMPLE
+    .\Connectto365.ps1 -LegacyMode
+
+.NOTES
+    Improved: added parameter support, module validation, and error handling.
+    Original: single New-PSSession call with no error handling.
+#>
+[CmdletBinding()]
+param(
+    [string]$UserPrincipalName,
+    [switch]$LegacyMode
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "Connectto365"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+}
+
+if ($LegacyMode) {
+    Write-Log "Using legacy PSSession mode." -Level WARN
+    try {
+        $cred = Get-Credential -Message "Enter Office 365 admin credentials" -UserName $UserPrincipalName
+        $session = New-PSSession `
+            -ConfigurationName Microsoft.Exchange `
+            -ConnectionUri https://ps.outlook.com/powershell/ `
+            -Credential $cred `
+            -Authentication Basic `
+            -AllowRedirection `
+            -ErrorAction Stop
+        Import-PSSession $session -DisableNameChecking -AllowClobber | Out-Null
+        Write-Log "Exchange Online session established (legacy)." -Level SUCCESS
+    }
+    catch {
+        Write-Log "Connection failed: $_" -Level ERROR
+        throw
+    }
+    return
+}
+
+# Modern path: ExchangeOnlineManagement module
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+    Write-Log "ExchangeOnlineManagement module not found." -Level ERROR
+    Write-Log "Install it with: Install-Module ExchangeOnlineManagement -Scope CurrentUser" -Level INFO
+    throw "Missing required module: ExchangeOnlineManagement"
+}
+
+try {
+    $connectParams = @{ ShowBanner = $false; ErrorAction = 'Stop' }
+    if ($UserPrincipalName) { $connectParams['UserPrincipalName'] = $UserPrincipalName }
+    Connect-ExchangeOnline @connectParams
+    Write-Log "Connected to Exchange Online successfully." -Level SUCCESS
+}
+catch {
+    Write-Log "Failed to connect to Exchange Online: $_" -Level ERROR
+    throw
+}

--- a/DisableIMAPandPOP.ps1
+++ b/DisableIMAPandPOP.ps1
@@ -1,1 +1,104 @@
-﻿Get-Mailbox | Set-CASMailbox –POPEnabled $False -ImapEnabled $False
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Disables IMAP and POP3 access on Exchange/EXO mailboxes.
+
+.DESCRIPTION
+    Sets ImapEnabled and PopEnabled to $false on all user mailboxes (default)
+    or a scoped subset. Supports -WhatIf and requires confirmation before
+    bulk changes.
+
+.PARAMETER Identity
+    Specific mailbox identity to target. If omitted, all mailboxes are targeted.
+
+.PARAMETER WhatIf
+    Preview the changes without applying them.
+
+.PARAMETER Force
+    Bypass the confirmation prompt.
+
+.EXAMPLE
+    .\DisableIMAPandPOP.ps1
+    # Disables on ALL mailboxes (prompts for confirmation)
+
+.EXAMPLE
+    .\DisableIMAPandPOP.ps1 -Identity user@contoso.com
+
+.EXAMPLE
+    .\DisableIMAPandPOP.ps1 -WhatIf
+    # Preview without changes
+
+.NOTES
+    Improved: added parameters, bulk confirmation prompt, per-mailbox error
+    handling, result summary, and logging.
+    Original: one-liner with no error handling, no confirmation, no logging.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$Identity,
+    [switch]$Force
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "DisableIMAPandPOP"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+    function Confirm-DestructiveAction {
+        param([string]$ActionDescription, [switch]$Force)
+        if ($Force) { return $true }
+        Write-Host "`n  *** WARNING *** $ActionDescription" -ForegroundColor Yellow
+        return (Read-Host "Type 'YES' to confirm") -eq 'YES'
+    }
+}
+
+# Retrieve target mailboxes
+Write-Log "Retrieving mailboxes..." -Level INFO
+try {
+    if ($Identity) {
+        $mailboxes = @(Get-Mailbox -Identity $Identity -ErrorAction Stop)
+    }
+    else {
+        $mailboxes = Get-Mailbox -ResultSize Unlimited -ErrorAction Stop
+    }
+}
+catch {
+    Write-Log "Failed to retrieve mailboxes: $_" -Level ERROR
+    throw
+}
+Write-Log "Found $($mailboxes.Count) mailbox(es)." -Level INFO
+
+# Confirm bulk operation
+if (-not $Identity -and -not $WhatIfPreference) {
+    $actionDesc = "Disable IMAP and POP3 on ALL $($mailboxes.Count) mailbox(es)."
+    if (-not (Confirm-DestructiveAction -ActionDescription $actionDesc -Force:$Force)) {
+        Write-Log "Operation cancelled by user." -Level INFO
+        return
+    }
+}
+
+$successCount = 0
+$failCount    = 0
+
+foreach ($mbx in $mailboxes) {
+    $id = $mbx.UserPrincipalName ?? $mbx.Identity
+    if ($PSCmdlet.ShouldProcess($id, "Set-CASMailbox -ImapEnabled `$false -PopEnabled `$false")) {
+        try {
+            Set-CASMailbox -Identity $mbx.Identity `
+                -ImapEnabled $false `
+                -PopEnabled $false `
+                -ErrorAction Stop
+            Write-Log "IMAP/POP disabled: $id" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "FAILED on $id: $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Success: $successCount  |  Failed: $failCount" -Level INFO

--- a/Exchange-SetUserProxy.ps1
+++ b/Exchange-SetUserProxy.ps1
@@ -1,6 +1,98 @@
-	Import-csv C:\csv\UsersNoProxy.csv | ForEach-Object {
-	$ID = $_.PrimarySmtpAddress
-	$alias = $_.Alias
-	$365Email = $alias + "@contoso.mail.onmicrosoft.com"
-	Set-Mailbox -Identity $ID -EmailAddresses @{add = $365Email}
-	}
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Adds a proxy email address to Exchange mailboxes from a CSV file.
+
+.DESCRIPTION
+    Reads a CSV containing PrimarySmtpAddress and Alias columns, then adds
+    a proxy address in the format <Alias>@<ProxyDomain> to each mailbox.
+
+.PARAMETER CsvPath
+    Path to the CSV file. Must contain 'PrimarySmtpAddress' and 'Alias' columns.
+    Defaults to .\UsersNoProxy.csv
+
+.PARAMETER ProxyDomain
+    The mail domain to use when building the proxy address
+    (e.g. "contoso.mail.onmicrosoft.com"). REQUIRED.
+
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.EXAMPLE
+    .\Exchange-SetUserProxy.ps1 `
+        -CsvPath C:\Data\UsersNoProxy.csv `
+        -ProxyDomain "contoso.mail.onmicrosoft.com"
+
+.NOTES
+    Improved: removed hardcoded CSV path and domain, added parameters, validation,
+    per-mailbox error handling, and logging.
+    Original: hardcoded C:\csv\UsersNoProxy.csv and contoso.mail.onmicrosoft.com.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$CsvPath = ".\UsersNoProxy.csv",
+
+    [Parameter(Mandatory)]
+    [string]$ProxyDomain
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "Exchange-SetUserProxy"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+}
+
+if (-not (Test-Path $CsvPath)) {
+    Write-Log "CSV file not found: $CsvPath" -Level ERROR
+    throw "CSV not found: $CsvPath"
+}
+
+$users = Import-Csv -Path $CsvPath
+if (-not $users) {
+    Write-Log "CSV is empty: $CsvPath" -Level ERROR
+    throw "CSV is empty."
+}
+
+$required = @('PrimarySmtpAddress', 'Alias')
+foreach ($col in $required) {
+    if ($col -notin $users[0].PSObject.Properties.Name) {
+        Write-Log "CSV missing required column: '$col'" -Level ERROR
+        throw "Missing column: $col"
+    }
+}
+
+Write-Log "CSV loaded: $CsvPath ($($users.Count) rows). Proxy domain: $ProxyDomain" -Level INFO
+
+$successCount = 0
+$failCount    = 0
+
+foreach ($user in $users) {
+    $id       = $user.PrimarySmtpAddress
+    $alias    = $user.Alias
+    $newProxy = "$alias@$ProxyDomain"
+
+    if (-not $id -or -not $alias) {
+        Write-Log "Skipping row with missing PrimarySmtpAddress or Alias." -Level WARN
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($id, "Add proxy address $newProxy")) {
+        try {
+            Set-Mailbox -Identity $id `
+                -EmailAddresses @{ add = $newProxy } `
+                -ErrorAction Stop
+            Write-Log "Added $newProxy to: $id" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "FAILED on $id: $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Success: $successCount  |  Failed: $failCount" -Level INFO

--- a/Forwarding.ps1
+++ b/Forwarding.ps1
@@ -1,14 +1,147 @@
-# Loop though the object returned by Get-Mailbox with each element represented by $mailbox
-foreach ($mailbox in (Get-MailBox -ResultSize Unlimited -OrganizationalUnit "elant.local/SITES [NEW]/Choice"))
-{
-# Create the forwarding address string
-$ForwardingAddress= $mailbox.SamAccountName + “@elantcare.org”
-# Check there isn’t a contact, then add one
-If (!(Get-MailContact $ForwardingAddress -ErrorAction SilentlyContinue))
-{
-New-MailContact $mailbox.displayName-ExternalEmailAddress $ForwardingAddress -OrganizationalUnit "elant.local/SITES [NEW]/Choice/Office365Contacts" | Set-MailContact -HiddenFromAddressListsEnabled $true
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Sets up mailbox forwarding to external contacts for users in a specified OU.
+
+.DESCRIPTION
+    Loops through mailboxes in the given Organizational Unit. For each mailbox,
+    creates a hidden mail contact at the forwarding email address (if one does
+    not already exist) and configures ForwardingAddress on the mailbox.
+
+.PARAMETER OrganizationalUnit
+    LDAP/canonical OU path to scope mailbox retrieval. REQUIRED.
+
+.PARAMETER ForwardingDomain
+    External domain appended to each user's SamAccountName to form the
+    forwarding email address. REQUIRED.
+
+.PARAMETER ContactsOU
+    OU where the mail contacts will be created. Defaults to a "Contacts"
+    sub-OU beneath OrganizationalUnit.
+
+.PARAMETER DeliverToMailboxAndForward
+    If $true (default), mail is delivered locally AND forwarded.
+    Set to $false to forward-only (no local copy).
+
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.PARAMETER Force
+    Skip the confirmation prompt.
+
+.EXAMPLE
+    .\Forwarding.ps1 `
+        -OrganizationalUnit "contoso.local/SITES/Branch" `
+        -ForwardingDomain "@contoso365.org" `
+        -ContactsOU "contoso.local/SITES/Branch/Contacts"
+
+.NOTES
+    Improved: removed hardcoded OU and domain, added parameters, error handling
+    per-mailbox, WhatIf support, confirmation prompt, and logging.
+    Original: hardcoded elant.local OU and @elantcare.org domain with no error handling.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$OrganizationalUnit,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^@.+\..+$')]
+    [string]$ForwardingDomain,
+
+    [string]$ContactsOU,
+
+    [bool]$DeliverToMailboxAndForward = $true,
+
+    [switch]$Force
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "Forwarding"
 }
-# Set the forwarding address
-Set-Mailbox -Identity $mailbox.SamAccountName -ForwardingAddress $ForwardingAddress -DeliverToMailboxAndForward $true
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+    function Confirm-DestructiveAction {
+        param([string]$ActionDescription, [switch]$Force)
+        if ($Force) { return $true }
+        Write-Host "`n  *** WARNING *** $ActionDescription" -ForegroundColor Yellow
+        return (Read-Host "Type 'YES' to confirm") -eq 'YES'
+    }
 }
 
+# Default contacts OU to a sub-OU of the source OU
+if (-not $ContactsOU) {
+    $ContactsOU = "$OrganizationalUnit/Office365Contacts"
+}
+
+$actionDesc = "Set forwarding to '$ForwardingDomain' for all mailboxes in OU '$OrganizationalUnit'."
+if (-not $WhatIfPreference) {
+    if (-not (Confirm-DestructiveAction -ActionDescription $actionDesc -Force:$Force)) {
+        Write-Log "Operation cancelled by user." -Level INFO
+        return
+    }
+}
+
+Write-Log "Retrieving mailboxes from OU: $OrganizationalUnit" -Level INFO
+try {
+    $mailboxes = Get-Mailbox -ResultSize Unlimited `
+        -OrganizationalUnit $OrganizationalUnit `
+        -ErrorAction Stop
+}
+catch {
+    Write-Log "Failed to retrieve mailboxes: $_" -Level ERROR
+    throw
+}
+Write-Log "Found $($mailboxes.Count) mailbox(es)." -Level INFO
+
+$successCount = 0
+$failCount    = 0
+
+foreach ($mailbox in $mailboxes) {
+    $forwardingAddress = $mailbox.SamAccountName + $ForwardingDomain
+    Write-Log "Processing: $($mailbox.DisplayName) -> $forwardingAddress" -Level INFO
+
+    if ($PSCmdlet.ShouldProcess($mailbox.DisplayName, "Set forwarding to $forwardingAddress")) {
+        # Create contact if it does not exist
+        $existingContact = Get-MailContact $forwardingAddress -ErrorAction SilentlyContinue
+        if (-not $existingContact) {
+            try {
+                New-MailContact `
+                    -Name $mailbox.DisplayName `
+                    -ExternalEmailAddress $forwardingAddress `
+                    -OrganizationalUnit $ContactsOU `
+                    -ErrorAction Stop |
+                    Set-MailContact -HiddenFromAddressListsEnabled $true -ErrorAction Stop
+                Write-Log "  Created hidden contact: $forwardingAddress" -Level SUCCESS
+            }
+            catch {
+                Write-Log "  Failed to create contact for $($mailbox.DisplayName): $_" -Level ERROR
+                $failCount++
+                continue
+            }
+        }
+        else {
+            Write-Log "  Contact already exists: $forwardingAddress" -Level INFO
+        }
+
+        # Set forwarding on the mailbox
+        try {
+            Set-Mailbox `
+                -Identity $mailbox.SamAccountName `
+                -ForwardingAddress $forwardingAddress `
+                -DeliverToMailboxAndForward $DeliverToMailboxAndForward `
+                -ErrorAction Stop
+            Write-Log "  Forwarding set on: $($mailbox.SamAccountName)" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "  Failed to set forwarding on $($mailbox.SamAccountName): $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Success: $successCount  |  Failed: $failCount" -Level INFO

--- a/FullMailboxPermissionsforAdmin.ps1
+++ b/FullMailboxPermissionsforAdmin.ps1
@@ -1,1 +1,99 @@
-﻿Get-Mailbox -ResultSize unlimited -Filter {(RecipientTypeDetails -eq 'UserMailbox')} | Add-MailboxPermission -User umsa@northwaybank.onmicrosoft.com -AccessRights FullAccess -InheritanceType all
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Grants Full Access mailbox permissions to a specified admin account.
+
+.DESCRIPTION
+    Iterates all user mailboxes and adds Full Access for the given admin UPN.
+    Supports -WhatIf for dry-run previews and requires explicit confirmation
+    before making changes.
+
+.PARAMETER AdminUPN
+    The admin account UPN to grant Full Access to. REQUIRED - no default.
+
+.PARAMETER WhatIf
+    Preview the changes without applying them.
+
+.PARAMETER Force
+    Skip the confirmation prompt (use in automation pipelines).
+
+.EXAMPLE
+    .\FullMailboxPermissionsforAdmin.ps1 -AdminUPN admin@contoso.onmicrosoft.com
+
+.EXAMPLE
+    .\FullMailboxPermissionsforAdmin.ps1 -AdminUPN admin@contoso.onmicrosoft.com -WhatIf
+
+.NOTES
+    Improved: removed hardcoded UPN, added -WhatIf support, confirmation prompt,
+    error handling per mailbox, and logging.
+    Original: single one-liner with hardcoded org-specific UPN.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[^@]+@[^@]+\.[^@]+$')]
+    [string]$AdminUPN,
+
+    [switch]$Force
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "FullMailboxPermissionsforAdmin"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+    function Confirm-DestructiveAction {
+        param([string]$ActionDescription, [switch]$Force)
+        if ($Force) { return $true }
+        Write-Host "`n  *** WARNING *** $ActionDescription" -ForegroundColor Yellow
+        return (Read-Host "Type 'YES' to confirm") -eq 'YES'
+    }
+}
+
+# Confirm before proceeding
+$actionDesc = "Grant '$AdminUPN' Full Access to ALL user mailboxes in the organization."
+if (-not $WhatIfPreference) {
+    if (-not (Confirm-DestructiveAction -ActionDescription $actionDesc -Force:$Force)) {
+        Write-Log "Operation cancelled by user." -Level INFO
+        return
+    }
+}
+
+Write-Log "Retrieving all user mailboxes..." -Level INFO
+try {
+    $mailboxes = Get-Mailbox -ResultSize Unlimited `
+        -Filter "RecipientTypeDetails -eq 'UserMailbox'" `
+        -ErrorAction Stop
+}
+catch {
+    Write-Log "Failed to retrieve mailboxes: $_" -Level ERROR
+    throw
+}
+Write-Log "Found $($mailboxes.Count) user mailbox(es)." -Level INFO
+
+$successCount = 0
+$failCount    = 0
+
+foreach ($mbx in $mailboxes) {
+    if ($PSCmdlet.ShouldProcess($mbx.UserPrincipalName, "Add-MailboxPermission FullAccess for $AdminUPN")) {
+        try {
+            Add-MailboxPermission `
+                -Identity $mbx.UserPrincipalName `
+                -User $AdminUPN `
+                -AccessRights FullAccess `
+                -InheritanceType All `
+                -ErrorAction Stop | Out-Null
+            Write-Log "Granted FullAccess on: $($mbx.UserPrincipalName)" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "FAILED on $($mbx.UserPrincipalName): $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Success: $successCount  |  Failed: $failCount" -Level INFO

--- a/Impersonation.ps1
+++ b/Impersonation.ps1
@@ -1,1 +1,94 @@
-﻿New-ManagementRoleAssignment –Role "ApplicationImpersonation" –User umsa@northwaybank.onmicrosoft.com
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Assigns (or removes) the ApplicationImpersonation management role to a user.
+
+.DESCRIPTION
+    Grants the ApplicationImpersonation RBAC role assignment, which allows a
+    service account to impersonate any mailbox. Requires confirmation before
+    applying because this is a high-privilege operation.
+
+.PARAMETER UserUPN
+    UPN of the account to assign the role to. REQUIRED - no default.
+
+.PARAMETER Remove
+    Remove the role assignment instead of adding it.
+
+.PARAMETER Force
+    Bypass the confirmation prompt (for automation pipelines).
+
+.EXAMPLE
+    .\Impersonation.ps1 -UserUPN serviceaccount@contoso.onmicrosoft.com
+
+.EXAMPLE
+    .\Impersonation.ps1 -UserUPN serviceaccount@contoso.onmicrosoft.com -Remove
+
+.NOTES
+    Improved: removed hardcoded UPN, added -Remove switch, confirmation prompt,
+    error handling, and logging.
+    Original: single New-ManagementRoleAssignment one-liner with hardcoded UPN.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[^@]+@[^@]+\.[^@]+$')]
+    [string]$UserUPN,
+
+    [switch]$Remove,
+    [switch]$Force
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "Impersonation"
+}
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+    function Confirm-DestructiveAction {
+        param([string]$ActionDescription, [switch]$Force)
+        if ($Force) { return $true }
+        Write-Host "`n  *** WARNING *** $ActionDescription" -ForegroundColor Yellow
+        return (Read-Host "Type 'YES' to confirm") -eq 'YES'
+    }
+}
+
+$roleName = "ApplicationImpersonation"
+$operation = if ($Remove) { "REMOVE" } else { "ASSIGN" }
+$actionDesc = "$operation the '$roleName' role to/from '$UserUPN'. This is a high-privilege operation."
+
+if (-not $WhatIfPreference) {
+    if (-not (Confirm-DestructiveAction -ActionDescription $actionDesc -Force:$Force)) {
+        Write-Log "Operation cancelled by user." -Level INFO
+        return
+    }
+}
+
+if ($Remove) {
+    Write-Log "Removing '$roleName' from '$UserUPN'..." -Level INFO
+    try {
+        if ($PSCmdlet.ShouldProcess($UserUPN, "Remove-ManagementRoleAssignment $roleName")) {
+            Get-ManagementRoleAssignment -Role $roleName -RoleAssignee $UserUPN -ErrorAction Stop |
+                Remove-ManagementRoleAssignment -Confirm:$false -ErrorAction Stop
+            Write-Log "Role '$roleName' removed from '$UserUPN'." -Level SUCCESS
+        }
+    }
+    catch {
+        Write-Log "Failed to remove role: $_" -Level ERROR
+        throw
+    }
+}
+else {
+    Write-Log "Assigning '$roleName' to '$UserUPN'..." -Level INFO
+    try {
+        if ($PSCmdlet.ShouldProcess($UserUPN, "New-ManagementRoleAssignment $roleName")) {
+            New-ManagementRoleAssignment -Role $roleName -User $UserUPN -ErrorAction Stop | Out-Null
+            Write-Log "Role '$roleName' assigned to '$UserUPN'." -Level SUCCESS
+        }
+    }
+    catch {
+        Write-Log "Failed to assign role: $_" -Level ERROR
+        throw
+    }
+}

--- a/Invoke-O365Automation.ps1
+++ b/Invoke-O365Automation.ps1
@@ -1,0 +1,389 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Combined Office 365 / Exchange automation menu.
+
+.DESCRIPTION
+    Interactive (or parameter-driven) automation hub that wraps the most common
+    PSforO365 administrative workflows into a single entry point:
+
+    1  User Provisioning      - Bulk create AD/M365 users and assign licenses
+    2  UPN Migration          - Bulk update User Principal Names from CSV
+    3  License Assignment     - Assign O365 licenses to users from CSV
+    4  Mailbox Permission Audit - Export Full Access / Send As / Send On Behalf
+    5  Proxy Address Repair   - Find and fix mailboxes missing proxy addresses
+    6  Bulk External Contacts - Import external mail contacts from CSV
+    7  Disable IMAP/POP       - Harden mailboxes by disabling legacy protocols
+    8  Mailbox Forwarding     - Set forwarding to external contacts by OU
+    9  Admin Full Access Grant - Grant admin Full Access to all user mailboxes
+    10 Exchange Health Check  - Run Test-ExchangeServerHealth report
+    11 Exchange Environment   - Run Get-ExchangeEnvironmentReport
+    0  Exit
+
+    Pass -Task <number> to run non-interactively (e.g. from a scheduled task).
+
+.PARAMETER Task
+    Task number to run directly (skips the menu). Use 0 for all tasks.
+
+.PARAMETER AdminUPN
+    Admin UPN used for connection and privileged tasks.
+
+.PARAMETER CsvPath
+    Default CSV path passed to tasks that require one.
+
+.PARAMETER OutputDirectory
+    Directory for logs and exported reports. Defaults to .\O365Reports.
+
+.PARAMETER LegacyMode
+    Use legacy PSSession connection instead of the ExchangeOnlineManagement module.
+
+.PARAMETER Force
+    Bypass confirmation prompts on destructive operations.
+
+.EXAMPLE
+    .\Invoke-O365Automation.ps1
+    # Interactive menu
+
+.EXAMPLE
+    .\Invoke-O365Automation.ps1 -Task 7 -Force
+    # Disable IMAP/POP on all mailboxes without prompting
+
+.EXAMPLE
+    .\Invoke-O365Automation.ps1 -Task 4 -OutputDirectory C:\AuditReports
+    # Run mailbox permission audit and save to specified directory
+
+.NOTES
+    Version: 1.0
+    Requires: PSO365-Utilities.psm1 in the same directory as this script.
+    Individual scripts for each workflow must also be present in the same directory.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [ValidateRange(0, 11)]
+    [int]$Task = -1,
+
+    [string]$AdminUPN,
+
+    [string]$CsvPath,
+
+    [string]$OutputDirectory = ".\O365Reports",
+
+    [switch]$LegacyMode,
+
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ─────────────────────────────────────────────
+# Bootstrap shared utilities
+# ─────────────────────────────────────────────
+$scriptRoot = $PSScriptRoot
+if (-not $scriptRoot) { $scriptRoot = Split-Path $MyInvocation.MyCommand.Path }
+
+$utilitiesPath = Join-Path $scriptRoot "PSO365-Utilities.psm1"
+if (-not (Test-Path $utilitiesPath)) {
+    Write-Error "PSO365-Utilities.psm1 not found at $utilitiesPath. Cannot continue."
+    exit 1
+}
+Import-Module $utilitiesPath -Force
+
+if (-not (Test-Path $OutputDirectory)) {
+    New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+}
+Initialize-Log -LogDirectory $OutputDirectory -ScriptName "Invoke-O365Automation"
+
+# ─────────────────────────────────────────────
+# Helper: resolve a path to a child script
+# ─────────────────────────────────────────────
+function Resolve-ChildScript {
+    param([string]$FileName)
+    $path = Join-Path $scriptRoot $FileName
+    if (-not (Test-Path $path)) {
+        Write-Log "Script not found: $path" -Level WARN
+        return $null
+    }
+    return $path
+}
+
+# ─────────────────────────────────────────────
+# Connection State
+# ─────────────────────────────────────────────
+$script:EXOConnected  = $false
+$script:MSOLConnected = $false
+
+function Ensure-EXOConnected {
+    if (-not $script:EXOConnected) {
+        Write-Log "Establishing Exchange Online connection..." -Level INFO
+        $connectParams = @{ LegacyMode = $LegacyMode }
+        if ($AdminUPN) { $connectParams['UserPrincipalName'] = $AdminUPN }
+        Connect-O365 @connectParams
+        $script:EXOConnected = $true
+    }
+}
+
+function Ensure-MSOLConnected {
+    if (-not $script:MSOLConnected) {
+        Write-Log "Establishing MSOnline connection..." -Level INFO
+        Connect-MSOnline
+        $script:MSOLConnected = $true
+    }
+}
+
+# ─────────────────────────────────────────────
+# Task Implementations
+# ─────────────────────────────────────────────
+
+function Invoke-UserProvisioning {
+    Write-Log "=== TASK: Bulk User Provisioning ===" -Level INFO
+    $csvPath = if ($CsvPath) { $CsvPath } else {
+        try { Get-CsvFilePath -Title "Select user provisioning CSV" }
+        catch { Write-Log "No CSV selected." -Level WARN; return }
+    }
+    $script1 = Resolve-ChildScript "Bulk User Creation\NewUserPS.ps1"
+    if (-not $script1) { Write-Log "Bulk user creation script not found." -Level ERROR; return }
+    Ensure-MSOLConnected
+    Write-Log "Running bulk user creation..." -Level INFO
+    & $script1 -CsvPath $csvPath
+    Write-Log "User provisioning complete." -Level SUCCESS
+}
+
+function Invoke-UPNMigration {
+    Write-Log "=== TASK: UPN Migration ===" -Level INFO
+    $csvPath = if ($CsvPath) { $CsvPath } else {
+        try { Get-CsvFilePath -Title "Select UPN migration CSV (columns: UserPrincipalName, EmailAddress)" }
+        catch { Write-Log "No CSV selected." -Level WARN; return }
+    }
+    $script1 = Resolve-ChildScript "UPNChange.PS1"
+    if (-not $script1) { Write-Log "UPNChange.PS1 not found." -Level ERROR; return }
+    & $script1 -CsvPath $csvPath
+}
+
+function Invoke-LicenseAssignment {
+    Write-Log "=== TASK: License Assignment ===" -Level INFO
+    Ensure-MSOLConnected
+    $script1 = Resolve-ChildScript "licenses.ps1"
+    if (-not $script1) { Write-Log "licenses.ps1 not found." -Level ERROR; return }
+    $params = @{}
+    if ($CsvPath)  { $params['CsvPath'] = $CsvPath }
+    if ($Force)    { $params['Force'] = $true }
+    & $script1 @params
+}
+
+function Invoke-MailboxPermissionAudit {
+    Write-Log "=== TASK: Mailbox Permission Audit ===" -Level INFO
+    Ensure-EXOConnected
+
+    $outFile = Join-Path $OutputDirectory ("MailboxPermissions_" + (Get-Date -Format "yyyyMMdd_HHmmss") + ".csv")
+    Write-Log "Output: $outFile" -Level INFO
+
+    $header = "DisplayName,EmailAddress,FullAccess,SendAs,SendOnBehalfOf"
+    $header | Out-File $outFile -Encoding UTF8 -Force
+
+    Write-Log "Retrieving mailboxes..." -Level INFO
+    $mailboxes = Get-Mailbox -ResultSize Unlimited |
+        Select-Object Identity, Alias, DisplayName, DistinguishedName, WindowsEmailAddress
+
+    $total = $mailboxes.Count
+    $i     = 0
+    foreach ($mbx in $mailboxes) {
+        $i++
+        Write-Progress -Activity "Auditing mailbox permissions" `
+                       -Status "$i of $total: $($mbx.DisplayName)" `
+                       -PercentComplete (($i / $total) * 100)
+        try {
+            $sendOnBehalf = (Get-Mailbox $mbx.Identity -ErrorAction Stop).GrantSendOnBehalfTo -join ";"
+            $sendAs = (Get-ADPermission $mbx.Identity -ErrorAction SilentlyContinue |
+                Where-Object { ($_.ExtendedRights -like "*Send-As*") -and
+                               ($_.User -notlike "NT AUTHORITY\SELF") -and
+                               ($_.User -notlike "S-1-5-21*") }).User -join ";"
+            $fullAccess = (Get-MailboxPermission $mbx.Identity -ErrorAction Stop |
+                Where-Object { (-not $_.IsInherited) -and
+                               ($_.User -notmatch "NT AUTHORITY") -and
+                               ($_.AccessRights -contains "FullAccess") }).User -join ";"
+
+            "$($mbx.DisplayName),$($mbx.WindowsEmailAddress),$fullAccess,$sendAs,$sendOnBehalf" |
+                Out-File $outFile -Append -Encoding UTF8
+        }
+        catch {
+            Write-Log "Error auditing $($mbx.DisplayName): $_" -Level WARN
+        }
+    }
+    Write-Progress -Activity "Auditing mailbox permissions" -Completed
+    Write-Log "Audit complete. Report saved: $outFile" -Level SUCCESS
+}
+
+function Invoke-ProxyAddressRepair {
+    Write-Log "=== TASK: Proxy Address Repair ===" -Level INFO
+    Ensure-EXOConnected
+
+    $domain = Read-Host "Enter the proxy domain (e.g. contoso.mail.onmicrosoft.com)"
+    if (-not $domain) { Write-Log "No domain entered." -Level WARN; return }
+
+    # Find mailboxes missing the proxy address
+    $noProxyFile = Join-Path $OutputDirectory ("UsersNoProxy_" + (Get-Date -Format "yyyyMMdd_HHmmss") + ".csv")
+    Write-Log "Scanning for mailboxes missing @$domain proxy address..." -Level INFO
+
+    $noProxyUsers = Get-Mailbox -ResultSize Unlimited | Where-Object {
+        $_.EmailAddresses -notmatch [regex]::Escape("@$domain")
+    } | Select-Object DisplayName, Alias, PrimarySmtpAddress
+
+    $noProxyUsers | Export-Csv $noProxyFile -NoTypeInformation
+    Write-Log "Found $($noProxyUsers.Count) mailbox(es) without @$domain. Saved: $noProxyFile" -Level INFO
+
+    if ($noProxyUsers.Count -eq 0) {
+        Write-Log "No proxy address repairs needed." -Level SUCCESS
+        return
+    }
+
+    $fix = Read-Host "Apply proxy addresses now? (YES to confirm)"
+    if ($fix -ne 'YES') { Write-Log "Repair skipped." -Level INFO; return }
+
+    $script1 = Resolve-ChildScript "Exchange-SetUserProxy.ps1"
+    if (-not $script1) { Write-Log "Exchange-SetUserProxy.ps1 not found." -Level ERROR; return }
+    & $script1 -CsvPath $noProxyFile -ProxyDomain $domain
+}
+
+function Invoke-BulkExternalContacts {
+    Write-Log "=== TASK: Bulk External Contacts Import ===" -Level INFO
+    Ensure-EXOConnected
+    $csvPath = if ($CsvPath) { $CsvPath } else {
+        try { Get-CsvFilePath -Title "Select external contacts CSV (columns: Name, ExternalEmailAddress, FirstName, LastName)" }
+        catch { Write-Log "No CSV selected." -Level WARN; return }
+    }
+    $script1 = Resolve-ChildScript "BulkAddExternalContacts.ps1"
+    if (-not $script1) { Write-Log "BulkAddExternalContacts.ps1 not found." -Level ERROR; return }
+    & $script1 -CsvPath $csvPath
+}
+
+function Invoke-DisableIMAPPOP {
+    Write-Log "=== TASK: Disable IMAP and POP3 ===" -Level INFO
+    Ensure-EXOConnected
+    $script1 = Resolve-ChildScript "DisableIMAPandPOP.ps1"
+    if (-not $script1) { Write-Log "DisableIMAPandPOP.ps1 not found." -Level ERROR; return }
+    $params = @{}
+    if ($Force) { $params['Force'] = $true }
+    & $script1 @params
+}
+
+function Invoke-MailboxForwarding {
+    Write-Log "=== TASK: Mailbox Forwarding Setup ===" -Level INFO
+    Ensure-EXOConnected
+    $ou     = Read-Host "Organizational Unit (e.g. contoso.local/SITES/Branch)"
+    $domain = Read-Host "Forwarding domain with @ prefix (e.g. @contoso365.org)"
+    if (-not $ou -or -not $domain) { Write-Log "OU and domain are required." -Level WARN; return }
+
+    $script1 = Resolve-ChildScript "Forwarding.ps1"
+    if (-not $script1) { Write-Log "Forwarding.ps1 not found." -Level ERROR; return }
+    $params = @{ OrganizationalUnit = $ou; ForwardingDomain = $domain }
+    if ($Force) { $params['Force'] = $true }
+    & $script1 @params
+}
+
+function Invoke-AdminFullAccess {
+    Write-Log "=== TASK: Grant Admin Full Access to All Mailboxes ===" -Level INFO
+    Ensure-EXOConnected
+    $admin = if ($AdminUPN) { $AdminUPN } else { Read-Host "Enter admin UPN" }
+    if (-not $admin) { Write-Log "Admin UPN required." -Level WARN; return }
+
+    $script1 = Resolve-ChildScript "FullMailboxPermissionsforAdmin.ps1"
+    if (-not $script1) { Write-Log "FullMailboxPermissionsforAdmin.ps1 not found." -Level ERROR; return }
+    $params = @{ AdminUPN = $admin }
+    if ($Force) { $params['Force'] = $true }
+    & $script1 @params
+}
+
+function Invoke-ExchangeHealthCheck {
+    Write-Log "=== TASK: Exchange Server Health Check ===" -Level INFO
+    $script1 = Resolve-ChildScript "Test-ExchangeServerHealth.ps1"
+    if (-not $script1) { Write-Log "Test-ExchangeServerHealth.ps1 not found." -Level ERROR; return }
+    & $script1
+}
+
+function Invoke-ExchangeEnvironmentReport {
+    Write-Log "=== TASK: Exchange Environment Report ===" -Level INFO
+    $script1 = Resolve-ChildScript "Get-ExchangeEnvironmentReport.ps1"
+    if (-not $script1) { Write-Log "Get-ExchangeEnvironmentReport.ps1 not found." -Level ERROR; return }
+    & $script1
+}
+
+# ─────────────────────────────────────────────
+# Task Dispatch Table
+# ─────────────────────────────────────────────
+$tasks = @{
+    1  = @{ Name = "User Provisioning";            Fn = { Invoke-UserProvisioning } }
+    2  = @{ Name = "UPN Migration";                Fn = { Invoke-UPNMigration } }
+    3  = @{ Name = "License Assignment";           Fn = { Invoke-LicenseAssignment } }
+    4  = @{ Name = "Mailbox Permission Audit";     Fn = { Invoke-MailboxPermissionAudit } }
+    5  = @{ Name = "Proxy Address Repair";         Fn = { Invoke-ProxyAddressRepair } }
+    6  = @{ Name = "Bulk External Contacts";       Fn = { Invoke-BulkExternalContacts } }
+    7  = @{ Name = "Disable IMAP/POP";             Fn = { Invoke-DisableIMAPPOP } }
+    8  = @{ Name = "Mailbox Forwarding Setup";     Fn = { Invoke-MailboxForwarding } }
+    9  = @{ Name = "Admin Full Access Grant";      Fn = { Invoke-AdminFullAccess } }
+    10 = @{ Name = "Exchange Health Check";        Fn = { Invoke-ExchangeHealthCheck } }
+    11 = @{ Name = "Exchange Environment Report";  Fn = { Invoke-ExchangeEnvironmentReport } }
+}
+
+function Show-Menu {
+    Write-Host ""
+    Write-Host "  ╔══════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "  ║       PSforO365 Automation Hub v1.0          ║" -ForegroundColor Cyan
+    Write-Host "  ╚══════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+    foreach ($key in ($tasks.Keys | Sort-Object)) {
+        Write-Host ("   {0,2}  {1}" -f $key, $tasks[$key].Name)
+    }
+    Write-Host "    0  Exit"
+    Write-Host ""
+}
+
+function Invoke-Task {
+    param([int]$TaskNumber)
+    if ($tasks.ContainsKey($TaskNumber)) {
+        Write-Log "Starting task $TaskNumber : $($tasks[$TaskNumber].Name)" -Level INFO
+        try {
+            & $tasks[$TaskNumber].Fn
+        }
+        catch {
+            Write-Log "Task $TaskNumber failed: $_" -Level ERROR
+        }
+    }
+    else {
+        Write-Log "Unknown task number: $TaskNumber" -Level WARN
+    }
+}
+
+# ─────────────────────────────────────────────
+# Entry Point
+# ─────────────────────────────────────────────
+if ($Task -ge 1) {
+    # Non-interactive: run the specified task directly
+    Invoke-Task -TaskNumber $Task
+}
+elseif ($Task -eq 0) {
+    # Run ALL tasks in sequence
+    Write-Log "Running all tasks in sequence..." -Level WARN
+    foreach ($key in ($tasks.Keys | Sort-Object)) {
+        Invoke-Task -TaskNumber $key
+    }
+}
+else {
+    # Interactive menu loop
+    do {
+        Show-Menu
+        $selection = Read-Host "  Select a task (0 to exit)"
+        if ($selection -match '^\d+$') {
+            $num = [int]$selection
+            if ($num -eq 0) { break }
+            Invoke-Task -TaskNumber $num
+        }
+        else {
+            Write-Host "  Invalid selection. Enter a number from the menu." -ForegroundColor Yellow
+        }
+        Write-Host ""
+        Read-Host "  Press Enter to return to the menu..."
+    } while ($true)
+
+    Write-Log "Exiting PSforO365 Automation Hub." -Level INFO
+}

--- a/PSO365-Utilities.psm1
+++ b/PSO365-Utilities.psm1
@@ -1,0 +1,314 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Shared utility functions for PSforO365 scripts.
+
+.DESCRIPTION
+    Common functions used across multiple Office 365 / Exchange management scripts:
+    - Logging
+    - O365 session connection
+    - CSV file selection
+    - Module/prerequisite validation
+    - Confirmation prompts for destructive operations
+
+.NOTES
+    Version: 1.0
+    Repository: PSforO365
+#>
+
+#region Logging
+
+$script:LogFile = $null
+
+function Initialize-Log {
+    <#
+    .SYNOPSIS
+        Initializes a log file for the current session.
+    .PARAMETER LogDirectory
+        Directory to write log files. Defaults to .\Logs.
+    .PARAMETER ScriptName
+        Name to use in the log filename.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$LogDirectory = ".\Logs",
+        [string]$ScriptName = "PSO365"
+    )
+    if (-not (Test-Path $LogDirectory)) {
+        New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
+    }
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $script:LogFile = Join-Path $LogDirectory "${ScriptName}_${timestamp}.log"
+    Write-Log "Log initialized. Script: $ScriptName" -Level INFO
+}
+
+function Write-Log {
+    <#
+    .SYNOPSIS
+        Writes a timestamped message to the console and optionally to a log file.
+    .PARAMETER Message
+        The message to log.
+    .PARAMETER Level
+        Log level: INFO, WARN, ERROR, SUCCESS. Defaults to INFO.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$Message,
+
+        [ValidateSet('INFO','WARN','ERROR','SUCCESS')]
+        [string]$Level = 'INFO'
+    )
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $entry = "[$timestamp] [$Level] $Message"
+
+    switch ($Level) {
+        'INFO'    { Write-Host $entry -ForegroundColor Cyan }
+        'WARN'    { Write-Host $entry -ForegroundColor Yellow }
+        'ERROR'   { Write-Host $entry -ForegroundColor Red }
+        'SUCCESS' { Write-Host $entry -ForegroundColor Green }
+    }
+
+    if ($script:LogFile) {
+        $entry | Out-File -FilePath $script:LogFile -Append -Encoding UTF8
+    }
+}
+
+#endregion
+
+#region Connection Management
+
+function Connect-O365 {
+    <#
+    .SYNOPSIS
+        Connects to Exchange Online using modern authentication (EXO V2/V3 module).
+    .DESCRIPTION
+        Checks for the ExchangeOnlineManagement module and connects. Falls back to
+        basic remote PowerShell if the module is not available (legacy environments).
+    .PARAMETER UserPrincipalName
+        Admin UPN to authenticate with (optional; omit to be prompted).
+    .PARAMETER LegacyMode
+        Use the old New-PSSession method (Exchange on-premises or EXO V1 tenants).
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$UserPrincipalName,
+        [switch]$LegacyMode
+    )
+
+    if ($LegacyMode) {
+        Write-Log "Connecting to Exchange Online (legacy PSSession mode)..." -Level INFO
+        try {
+            $cred = Get-Credential -Message "Enter your Office 365 admin credentials" `
+                                   -UserName $UserPrincipalName
+            $session = New-PSSession `
+                -ConfigurationName Microsoft.Exchange `
+                -ConnectionUri https://ps.outlook.com/powershell/ `
+                -Credential $cred `
+                -Authentication Basic `
+                -AllowRedirection `
+                -ErrorAction Stop
+            Import-PSSession $session -DisableNameChecking -AllowClobber | Out-Null
+            Write-Log "Legacy PSSession connected successfully." -Level SUCCESS
+        }
+        catch {
+            Write-Log "Failed to create legacy PSSession: $_" -Level ERROR
+            throw
+        }
+        return
+    }
+
+    # Modern EXO V2/V3
+    if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+        Write-Log "ExchangeOnlineManagement module not found. Install with: Install-Module ExchangeOnlineManagement" -Level ERROR
+        throw "Missing module: ExchangeOnlineManagement"
+    }
+
+    Write-Log "Connecting to Exchange Online (ExchangeOnlineManagement module)..." -Level INFO
+    try {
+        $connectParams = @{ ShowBanner = $false; ErrorAction = 'Stop' }
+        if ($UserPrincipalName) { $connectParams['UserPrincipalName'] = $UserPrincipalName }
+        Connect-ExchangeOnline @connectParams
+        Write-Log "Connected to Exchange Online successfully." -Level SUCCESS
+    }
+    catch {
+        Write-Log "Failed to connect to Exchange Online: $_" -Level ERROR
+        throw
+    }
+}
+
+function Connect-MSOnline {
+    <#
+    .SYNOPSIS
+        Connects to Microsoft Online Service (MSOnline / MSOL).
+    .DESCRIPTION
+        Validates the MSOnline module is present then connects.
+    #>
+    [CmdletBinding()]
+    param()
+
+    Assert-ModuleAvailable -ModuleName MSOnline
+    Write-Log "Connecting to Microsoft Online Service..." -Level INFO
+    try {
+        Connect-MsolService -ErrorAction Stop
+        Write-Log "Connected to MSOnline successfully." -Level SUCCESS
+    }
+    catch {
+        Write-Log "Failed to connect to MSOnline: $_" -Level ERROR
+        throw
+    }
+}
+
+#endregion
+
+#region Module / Prerequisite Validation
+
+function Assert-ModuleAvailable {
+    <#
+    .SYNOPSIS
+        Throws an error if a required PowerShell module is not installed.
+    .PARAMETER ModuleName
+        Name of the module to check.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ModuleName
+    )
+    if (-not (Get-Module -ListAvailable -Name $ModuleName)) {
+        $msg = "Required module '$ModuleName' is not installed. Run: Install-Module $ModuleName"
+        Write-Log $msg -Level ERROR
+        throw $msg
+    }
+    Write-Log "Module '$ModuleName' is available." -Level INFO
+}
+
+function Assert-RunningAsAdmin {
+    <#
+    .SYNOPSIS
+        Throws if the script is not running with administrator privileges.
+    #>
+    $current = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($current)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        $msg = "This script must be run as Administrator."
+        Write-Log $msg -Level ERROR
+        throw $msg
+    }
+}
+
+#endregion
+
+#region File Helpers
+
+function Get-CsvFilePath {
+    <#
+    .SYNOPSIS
+        Opens a GUI file-picker dialog and returns the selected CSV path.
+    .PARAMETER InitialDirectory
+        Starting directory for the dialog. Defaults to user's Desktop.
+    .PARAMETER Title
+        Dialog window title.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$InitialDirectory = [Environment]::GetFolderPath('Desktop'),
+        [string]$Title = "Select CSV File"
+    )
+    Add-Type -AssemblyName System.Windows.Forms | Out-Null
+    $dialog = New-Object System.Windows.Forms.OpenFileDialog
+    $dialog.Title            = $Title
+    $dialog.InitialDirectory = $InitialDirectory
+    $dialog.Filter           = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+    if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+        return $dialog.FileName
+    }
+    else {
+        throw "No file selected."
+    }
+}
+
+function Import-CsvSafe {
+    <#
+    .SYNOPSIS
+        Imports a CSV with validation. Throws if the file is missing or empty.
+    .PARAMETER Path
+        Path to the CSV file.
+    .PARAMETER RequiredColumns
+        Optional array of column names that must exist in the CSV.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [string[]]$RequiredColumns
+    )
+    if (-not (Test-Path $Path)) {
+        $msg = "CSV file not found: $Path"
+        Write-Log $msg -Level ERROR
+        throw $msg
+    }
+    $data = Import-Csv -Path $Path
+    if (-not $data) {
+        $msg = "CSV file is empty: $Path"
+        Write-Log $msg -Level ERROR
+        throw $msg
+    }
+    if ($RequiredColumns) {
+        $headers = $data[0].PSObject.Properties.Name
+        foreach ($col in $RequiredColumns) {
+            if ($col -notin $headers) {
+                $msg = "CSV is missing required column: '$col'"
+                Write-Log $msg -Level ERROR
+                throw $msg
+            }
+        }
+    }
+    Write-Log "CSV loaded: $Path ($($data.Count) rows)" -Level INFO
+    return $data
+}
+
+#endregion
+
+#region Safety Helpers
+
+function Confirm-DestructiveAction {
+    <#
+    .SYNOPSIS
+        Prompts the user to confirm a potentially destructive action.
+    .PARAMETER ActionDescription
+        Human-readable description of what the action will do.
+    .PARAMETER Force
+        Bypasses the prompt (for automation / -Force scenarios).
+    .RETURNS
+        $true if confirmed, $false if cancelled.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ActionDescription,
+        [switch]$Force
+    )
+    if ($Force) { return $true }
+
+    Write-Host ""
+    Write-Host "  *** DESTRUCTIVE ACTION WARNING ***" -ForegroundColor Red
+    Write-Host "  $ActionDescription" -ForegroundColor Yellow
+    Write-Host ""
+    $response = Read-Host "  Type 'YES' to confirm, anything else to cancel"
+    if ($response -eq 'YES') {
+        Write-Log "User confirmed: $ActionDescription" -Level WARN
+        return $true
+    }
+    Write-Log "User cancelled: $ActionDescription" -Level INFO
+    return $false
+}
+
+#endregion
+
+Export-ModuleMember -Function `
+    Initialize-Log, Write-Log, `
+    Connect-O365, Connect-MSOnline, `
+    Assert-ModuleAvailable, Assert-RunningAsAdmin, `
+    Get-CsvFilePath, Import-CsvSafe, `
+    Confirm-DestructiveAction

--- a/UPNChange.PS1
+++ b/UPNChange.PS1
@@ -1,16 +1,116 @@
-﻿#Script to Change the UPN on the Active Directory#
-#This script should run from an Active Directory Module for Windows PowerShell#
-#Version 1.0 – 06/30/2015#
-#Author: Antonio Vargas#
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Bulk changes Active Directory User Principal Names from a CSV file.
 
-$UserCount = 0
+.DESCRIPTION
+    Reads a CSV containing current UPNs (UserPrincipalName) and the desired new
+    UPNs (EmailAddress) and updates each AD user object. Requires the Active
+    Directory module. Skips users not found in AD and reports failures.
 
-Import-Csv -Path C:\FiestaLogonCSVTest.csv | ForEach-Object {
+.PARAMETER CsvPath
+    Path to the CSV file. Must contain 'UserPrincipalName' (current) and
+    'EmailAddress' (new UPN) columns. REQUIRED.
 
-$UPN = $_.UserPrincipalName
-Write-Host “Working on user:” $UPN
-Get-ADUser -Filter {UserPrincipalName -Eq $UPN} | Set-AdUser -userprincipalname $_.EmailAddress
-$usercount = $usercount +1
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.EXAMPLE
+    .\UPNChange.ps1 -CsvPath C:\Data\users.csv
+
+.NOTES
+    Improved: replaced hardcoded path, added parameters, AD module check,
+    per-user error handling, not-found detection, result summary, and logging.
+    Original: hardcoded C:\FiestaLogonCSVTest.csv with no error handling.
+    Author: Antonio Vargas (original v1.0, 06/30/2015)
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$CsvPath
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "UPNChange"
 }
-Write-Host “Number of users on your CSV: $UserCount”
-Write-Host “UPN’s Changed”
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
+}
+
+# Validate AD module
+if (-not (Get-Module -ListAvailable -Name ActiveDirectory)) {
+    Write-Log "ActiveDirectory module not found. Install RSAT or run on a domain controller." -Level ERROR
+    throw "Missing module: ActiveDirectory"
+}
+Import-Module ActiveDirectory -ErrorAction Stop
+
+# Load and validate CSV
+if (-not (Test-Path $CsvPath)) {
+    Write-Log "CSV not found: $CsvPath" -Level ERROR
+    throw "CSV not found: $CsvPath"
+}
+
+$users = Import-Csv -Path $CsvPath
+if (-not $users) {
+    Write-Log "CSV is empty: $CsvPath" -Level ERROR
+    throw "CSV is empty."
+}
+
+$required = @('UserPrincipalName', 'EmailAddress')
+foreach ($col in $required) {
+    if ($col -notin $users[0].PSObject.Properties.Name) {
+        Write-Log "CSV missing required column: '$col'" -Level ERROR
+        throw "Missing column: $col"
+    }
+}
+
+Write-Log "CSV loaded: $CsvPath ($($users.Count) rows)" -Level INFO
+
+$successCount  = 0
+$failCount     = 0
+$notFoundCount = 0
+
+foreach ($user in $users) {
+    $currentUPN = $user.UserPrincipalName
+    $newUPN     = $user.EmailAddress
+
+    if (-not $currentUPN -or -not $newUPN) {
+        Write-Log "Skipping row with missing UPN or EmailAddress." -Level WARN
+        $failCount++
+        continue
+    }
+
+    Write-Log "Processing: $currentUPN -> $newUPN" -Level INFO
+
+    try {
+        $adUser = Get-ADUser -Filter "UserPrincipalName -eq '$currentUPN'" -ErrorAction Stop
+    }
+    catch {
+        Write-Log "AD query failed for $currentUPN: $_" -Level ERROR
+        $failCount++
+        continue
+    }
+
+    if (-not $adUser) {
+        Write-Log "User not found in AD: $currentUPN" -Level WARN
+        $notFoundCount++
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($currentUPN, "Set UPN to $newUPN")) {
+        try {
+            Set-ADUser -Identity $adUser -UserPrincipalName $newUPN -ErrorAction Stop
+            Write-Log "  UPN updated: $currentUPN -> $newUPN" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "  FAILED: $currentUPN - $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Updated: $successCount  |  Not Found: $notFoundCount  |  Failed: $failCount" -Level INFO

--- a/licenses.ps1
+++ b/licenses.ps1
@@ -1,33 +1,149 @@
-Connect-MsolService
-#CSV file picker module start
-Function Get-FileName($initialDirectory)
-{ 
- [System.Reflection.Assembly]::LoadWithPartialName(“System.windows.forms”) |
- Out-Null
- 
- $OpenFileDialog = New-Object System.Windows.Forms.OpenFileDialog
- $OpenFileDialog.initialDirectory = $initialDirectory
- $OpenFileDialog.filter = “All files (*.*)| *.*”
- $OpenFileDialog.ShowDialog() | Out-Null
- $OpenFileDialog.filename
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Assigns an Office 365 license to users listed in a CSV file.
+
+.DESCRIPTION
+    Reads a CSV of user UPNs, sets the usage location on each account, then
+    applies the specified license SKU. Displays available SKUs in a grid view
+    to help identify the correct AccountSkuId.
+
+.PARAMETER CsvPath
+    Path to the CSV file. Must contain a 'UserPrincipalName' column.
+    If omitted, a file-picker dialog will open.
+
+.PARAMETER LicenseSku
+    The AccountSkuId of the license to assign (e.g. "contoso:ENTERPRISEPACK").
+    If omitted, available SKUs are shown and you will be prompted.
+
+.PARAMETER UsageLocation
+    Two-letter ISO country code for the usage location (e.g. "US", "GB", "CA").
+    Defaults to "US". REQUIRED by M365 before assigning a license.
+
+.EXAMPLE
+    .\licenses.ps1 -CsvPath C:\users.csv -LicenseSku "contoso:ENTERPRISEPACK" -UsageLocation US
+
+.EXAMPLE
+    .\licenses.ps1
+    # Interactive: opens file picker and shows SKU grid
+
+.NOTES
+    Improved: replaced hardcoded usage location and path, added parameters,
+    CSV validation, per-user error handling, result summary, and logging.
+    Original: hardcoded 'US' usage location, no error handling, no logging.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$CsvPath,
+
+    [string]$LicenseSku,
+
+    [ValidateLength(2, 2)]
+    [string]$UsageLocation = "US"
+)
+
+# Import shared utilities if available
+$utilitiesPath = Join-Path $PSScriptRoot "PSO365-Utilities.psm1"
+if (Test-Path $utilitiesPath) {
+    Import-Module $utilitiesPath -Force
+    Initialize-Log -ScriptName "AssignLicenses"
 }
- 
-#CSV file picker module end
- 
-#Variable that holds CSV file location from file picker
-$path = Get-FileName -initialDirectory “c:\”
- 
-#Window with list of available 365 licenses and their names
-Get-MsolAccountSku | out-gridview
- 
-#Input window where you provide the license package’s name
-$server = read-host ‘Provide licensename (AccountSkuId)’
- 
-#CSV import command and mailbox creation loop
-import-csv $path | foreach {
-Set-MsolUser -UserPrincipalName $_.UserPrincipalName -usagelocation “US”
-Set-MsolUserLicense -UserPrincipalName $_.UserPrincipalName -AddLicenses “$server”
+else {
+    function Write-Log { param([string]$Message, [string]$Level = 'INFO') Write-Host "[$Level] $Message" }
 }
- 
-#Result report on licenses assigned to imported users
-import-csv $path | Get-MSOLUser | out-gridview
+
+# ---- Connect to MSOnline ----
+Write-Log "Connecting to Microsoft Online Service..." -Level INFO
+try {
+    Connect-MsolService -ErrorAction Stop
+    Write-Log "Connected." -Level SUCCESS
+}
+catch {
+    Write-Log "Failed to connect to MSOnline: $_" -Level ERROR
+    throw
+}
+
+# ---- Select CSV ----
+if (-not $CsvPath) {
+    Write-Log "No CSV path provided - opening file picker." -Level INFO
+    try {
+        Add-Type -AssemblyName System.Windows.Forms | Out-Null
+        $dialog = New-Object System.Windows.Forms.OpenFileDialog
+        $dialog.Title            = "Select user CSV file"
+        $dialog.InitialDirectory = [Environment]::GetFolderPath('Desktop')
+        $dialog.Filter           = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+        if ($dialog.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) {
+            Write-Log "No file selected. Exiting." -Level WARN
+            return
+        }
+        $CsvPath = $dialog.FileName
+    }
+    catch {
+        Write-Log "File picker failed: $_" -Level ERROR
+        $CsvPath = Read-Host "Enter the full path to the CSV file"
+    }
+}
+
+if (-not (Test-Path $CsvPath)) {
+    Write-Log "CSV file not found: $CsvPath" -Level ERROR
+    throw "CSV file not found: $CsvPath"
+}
+
+$users = Import-Csv -Path $CsvPath
+if (-not $users) {
+    Write-Log "CSV file is empty: $CsvPath" -Level ERROR
+    throw "CSV file is empty."
+}
+if ('UserPrincipalName' -notin $users[0].PSObject.Properties.Name) {
+    Write-Log "CSV must contain a 'UserPrincipalName' column." -Level ERROR
+    throw "Missing required CSV column: UserPrincipalName"
+}
+Write-Log "CSV loaded: $CsvPath ($($users.Count) rows)" -Level INFO
+
+# ---- Select License SKU ----
+if (-not $LicenseSku) {
+    Write-Log "Available license SKUs:" -Level INFO
+    $skus = Get-MsolAccountSku
+    $selected = $skus | Out-GridView -Title "Select a license SKU" -PassThru
+    if (-not $selected) {
+        Write-Log "No SKU selected. Exiting." -Level WARN
+        return
+    }
+    $LicenseSku = $selected.AccountSkuId
+}
+Write-Log "License SKU: $LicenseSku | Usage Location: $UsageLocation" -Level INFO
+
+# ---- Assign licenses ----
+$successCount = 0
+$failCount    = 0
+$skipCount    = 0
+
+foreach ($user in $users) {
+    $upn = $user.UserPrincipalName
+    if (-not $upn) {
+        Write-Log "Skipping row with empty UserPrincipalName." -Level WARN
+        $skipCount++
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($upn, "Set usage location '$UsageLocation' and assign license '$LicenseSku'")) {
+        try {
+            Set-MsolUser -UserPrincipalName $upn -UsageLocation $UsageLocation -ErrorAction Stop
+            Set-MsolUserLicense -UserPrincipalName $upn -AddLicenses $LicenseSku -ErrorAction Stop
+            Write-Log "Licensed: $upn" -Level SUCCESS
+            $successCount++
+        }
+        catch {
+            Write-Log "FAILED: $upn - $_" -Level ERROR
+            $failCount++
+        }
+    }
+}
+
+Write-Log "Complete. Success: $successCount  |  Failed: $failCount  |  Skipped: $skipCount" -Level INFO
+
+# Show results grid
+Write-Log "Loading result view..." -Level INFO
+Import-Csv -Path $CsvPath | ForEach-Object {
+    Get-MsolUser -UserPrincipalName $_.UserPrincipalName -ErrorAction SilentlyContinue
+} | Out-GridView -Title "License Assignment Results"


### PR DESCRIPTION
Improvements across the repository based on a full script review:

New files:
- PSO365-Utilities.psm1: shared module providing Write-Log, Connect-O365, Connect-MSOnline, Assert-ModuleAvailable, Assert-RunningAsAdmin, Get-CsvFilePath, Import-CsvSafe, and Confirm-DestructiveAction.
- Invoke-O365Automation.ps1: interactive/parameter-driven automation hub with a menu covering 11 common O365/Exchange admin workflows.

Script hardening (all scripts below):
- Removed hardcoded org-specific values (UPNs, domains, file paths)
- Added mandatory or defaulted parameters instead of hardcoded values
- Added try/catch error handling with per-item failure tracking
- Added -WhatIf / SupportsShouldProcess to destructive operations
- Added explicit confirmation prompts before bulk destructive actions
- Added structured logging via PSO365-Utilities Write-Log
- Added CSV column validation before processing
- Added module prerequisite checks where needed
- Added result summaries (success/failed/skipped counts)

Scripts updated:
  Connectto365.ps1, FullMailboxPermissionsforAdmin.ps1, Impersonation.ps1, Forwarding.ps1, licenses.ps1, Exchange-SetUserProxy.ps1, BulkAddExternalContacts.ps1, DisableIMAPandPOP.ps1, UPNChange.PS1
